### PR TITLE
Make regex for /* */ comments less greedy.

### DIFF
--- a/SASS.plist
+++ b/SASS.plist
@@ -342,7 +342,7 @@
     <dict>
         <key>Comment Pattern</key>
         <string><![CDATA[(?x:
-				(//.*$) | (/\*(\s*|\n*|\t*|\r*|.*)*\*/)
+				(//.*$) | (/\*(.|[\r\n])*?\*/)
 			)]]></string>
 			<key>Function Pattern</key>
 			<string><![CDATA[(?x:


### PR DESCRIPTION
I'm seeing the first `/* */` comment in my .scss file erroneously extend past the `*/` and all the way to the last `/* */` comment in the file.

Did some googling and found this page on the proper way to regex for `/* */` comments. http://ostermiller.org/findcomment.html

yayz for the internets!
